### PR TITLE
Update cursor focus

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProToPortal"
 uuid = "f9496bd6-a3bb-4afc-927d-7268532ebfa9"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.1.0"
+version = "0.2.0-DEV"
 
 [deps]
 GenieFramework = "a59fdf5c-6bf0-4f5d-949c-a137c9e2f353"

--- a/src/view_chat.jl
+++ b/src/view_chat.jl
@@ -12,13 +12,15 @@ function tab_chat_settings()
                 [
                     btn("Delete last message",
                         icon = "delete", @click(:chat_rm_last_msg)),
-                    btn("New Chat", icon = "refresh", @click(:chat_reset))]),
+                    btn("New Chat", icon = "refresh", @click(:chat_reset)),
+                    btn("Fork Conversation", icon = "refresh", @click(:chat_fork))
+                ]),
             separator(),
             p("Generation Settings", class = "text-lg text-weight-bold pt-4"),
             p("Temperature (0=conservative, 2=crazy)"),
             slider(
                 0.0:0.1:2, :chat_temperature, labelalways = true, snap = true,
-                markers = 1, label = "Temperature"),
+                markers = 1),
             ##,
             separator(),
             p("Code Evaluation", class = "text-lg text-weight-bold"),
@@ -66,6 +68,7 @@ function tab_chat_templates()
         dense = true,
         densetoggle = true,
         v__model = :chat_template_expanded,
+        @on(:click, "focusTemplateSelect"),
         expandseparator = true,
         headerstyle = "bg-blue-1",
         [
@@ -75,6 +78,7 @@ function tab_chat_templates()
                 label = "Template",
                 clearable = true,
                 useinput = true,
+                ref = "tpl_select",
                 class = "pb-4",
                 @on(:filter, "filterFn")
             ),
@@ -87,7 +91,8 @@ function tab_chat_templates()
                 key! = R"item.id",
                 [
                     textfield(R"item.variable", v__model = "item.content",
-                    @on("keyup.enter.ctrl", "chat_submit!=chat_submit")
+                    ref = "variables",
+                    @on("keyup.enter.ctrl", "chat_submit=true")
                 )
                 ])
         ]
@@ -118,7 +123,12 @@ function tab_chat_messages()
             btngroup(flat = true, class = "absolute bottom-0 right-0",
                 [
                     btn(flat = true, round = true, size = "xs",
-                    icon = "content_copy", @click("copyToClipboard(index)"))
+                        icon = "content_copy", @click("copyToClipboard(index)")),
+                    ## show only for the last, no confirmation required
+                    btn(flat = true, round = true, size = "xs",
+                        icon = "delete", @iif("index == conv_displayed.length-1"),
+                        @click(:chat_rm_last_msg)
+                    )
                 ])]
     )
 end


### PR DESCRIPTION
Chat tab
- added delete icon to the last message in the conversation (for easy deletion)
- added a button in "Advanced Settings" to "Fork a conversation" (save to history for reference, but continue from a fresh copy)
- added a focus when a template is selected (on expand, on template selection, etc)